### PR TITLE
index/home: removed index.php from url redirects

### DIFF
--- a/src/app/home/index.php
+++ b/src/app/home/index.php
@@ -27,8 +27,8 @@ include "../navbar/navbar.php"
         </div>
     </div>
     <div class="buttons pt-4 row">
-        <a href="../register/index.php" class="btn ll-button" role="button">Sign Up</a>
-        <a href="../login/index.php" class="btn ll-button" role="button">Log In</a>
+        <a href="../register/" class="btn ll-button" role="button">Sign Up</a>
+        <a href="../login/" class="btn ll-button" role="button">Log In</a>
     </div>
 
 </div>

--- a/src/app/navbar/navbar.php
+++ b/src/app/navbar/navbar.php
@@ -75,7 +75,7 @@
 <nav class="navbar navbar-expand-sm bg-body-tertiary fixed-top">
   <div class="container-fluid">
     <!-- LOGO -->
-    <a class="nav-logo-link" href="../home/index.php">
+    <a class="nav-logo-link" href="../home/">
       <!-- todo: replace this href with link to homepage/dashboard based on if logged in (and all other links) -->
       <div class="nav-logo">
         <img


### PR DESCRIPTION
After using redirects from home page, the url was suffixed with 'index.php'. Made them redirect to the directory (which displays index.php without the suffix)