### PR TITLE
bugfix: fixed navbar overflowing for small phone screens

### DIFF
--- a/src/app/navbar/navbar.php
+++ b/src/app/navbar/navbar.php
@@ -50,6 +50,7 @@
         font-family: Bungee, sans-serif;
         font-size: 24px;
         line-height: 24px;
+        max-width: 50vw;
     }
 
     .nav-link:hover {


### PR DESCRIPTION
 - Set a max width of the LOVE LANGUAGES text so that at screens of 320px, the navbar doesn't overflow to the next line